### PR TITLE
Drag/Drop squadron creation workflow

### DIFF
--- a/src/apps/Formation/app.mjs
+++ b/src/apps/Formation/app.mjs
@@ -6,6 +6,21 @@ export default class extends Application {
 
   static register() {
     loadTemplates([this.template]);
+
+    MODULE.applySettings({
+      creationPings: {
+        scope: 'world',
+        config: true,
+        default: 0,
+        type: Number,
+        choices: {
+          0: 'sqdrn.setting.creationPings.all',
+          1: 'sqdrn.setting.creationPings.players',
+          2: 'sqdrn.setting.creationPings.gm',
+          3: 'sqdrn.setting.creationPings.none',
+        },
+      }
+    });
   }
 
   static get defaultOptions() {
@@ -16,8 +31,6 @@ export default class extends Application {
       top: 150,
     });
   }
-
-  
 
   constructor({leader = null, followers = [], scene = null}, options = {}) {
     super(options);
@@ -50,7 +63,10 @@ export default class extends Application {
 
     evt.preventDefault();
     evt.stopPropagation();
-    this.squad.leader ??= game.user.targets.first()?.id;
+
+    /* Even if we were assigned a leader on construction, always use
+     * the current user target (if any) */
+    this.squad.leader = game.user.targets.first()?.id ?? this.squad.leader;
 
     if (!this.squad.leader) {
       ui.notifications.info(MODULE.localize('feedback.pickTarget'));
@@ -84,7 +100,7 @@ export default class extends Application {
     return this.startFollow(squadData);
   }
 
-  async startFollow(squadData) {
+  async startFollow(squadData, silent = false) {
     if (!this.squad.leader) {
       throw new Error('Leader token required for squadron creation.');
     }
@@ -94,8 +110,8 @@ export default class extends Application {
       const tRay = Ray.fromAngle(0,0, Math.toRadians(tRot + 90), 1);
       squadData.orientationVector = {
         mode: 'vector',
-        x: Math.abs(tRay.dx < 1e-10) ? 0 : -tRay.B.x,
-        y: Math.abs(tRay.dy < 1e-10) ? 0 : tRay.B.y,
+        x: -tRay.B.x,
+        y: tRay.B.y,
       }
     } 
 
@@ -117,9 +133,74 @@ export default class extends Application {
     }
 
     /* confirmation info */
-    const type = squadData.orientationVector.mode === 'vector' ? 'formation' : 'follow';
-    const confirmInfo = MODULE.format(`feedback.pickConfirm.${type}`, {num: data.length})
-    ui.notifications.info(confirmInfo);
+    if (!silent) {
+      const type = squadData.orientationVector.mode === 'vector' ? 'formation' : 'follow';
+
+      const confirmInfo = MODULE.format(`feedback.pickConfirm.${type}`, {num: data.length})
+      ui.notifications.info(confirmInfo);
+
+      switch (MODULE.setting('creationPings')) {
+        case 0:
+          break;
+        case 1:
+          if (game.user.hasRole(CONST.USER_ROLES.PLAYER) && !game.user.isGM) break;
+          return data;
+        case 2:
+          if (game.user.isGM) break;
+          return data;
+        case 3:
+          return data;
+      }
+
+      const leaderObject = this.leader.object;
+      const followerObjects = this.squad.followers.map( id => game.scenes.get(this.squad.scene).tokens.get(id)?.object ).filter( p => p );
+
+      /* Chevron on leader */
+      if (leaderObject) {
+        const bounds = leaderObject.bounds;
+        canvas.ping(bounds.center, {
+          style: CONFIG.Canvas.pings.types.PULL,
+          size: (bounds.width + bounds.height) / 2,
+          duration: 1000,
+        });
+      }
+
+      switch (type) {
+        case 'formation':
+          /* Chevron on leader, rotated arrows on followers */
+          const rotRay = new Ray({
+            x: -squadData.orientationVector.x,
+            y: squadData.orientationVector.y
+          },{
+            x: 0, y: 0
+          });
+          followerObjects.forEach( p => {
+            const bounds = p.bounds;
+            canvas.ping(bounds.center, {
+              style: CONFIG.Canvas.pings.types.ARROW,
+              size: (bounds.width + bounds.height),
+              rotation: rotRay.angle + Math.PI,
+              duration: 1500,
+            });
+          });
+
+          break;
+        case 'follow':
+          /* Chevron on leader, pulses on followers */
+          followerObjects.forEach( p => {
+            const bounds = p.bounds;
+            canvas.ping(bounds.center, {
+              style: CONFIG.Canvas.pings.types.PULSE,
+              size: (bounds.width + bounds.height) / 2,
+              rings: 4,
+              duration: 1000,
+            });
+          });
+
+          break;
+      }
+
+    }
 
     return data;
   }

--- a/src/apps/Formation/app.mjs
+++ b/src/apps/Formation/app.mjs
@@ -24,8 +24,8 @@ export default class extends Application {
 
     if (typeof followers == 'string') followers = [followers];
 
-    if(!leader || followers.length == 0 || !scene) {
-      throw new Error('leader, follower(s), and scene IDs required');
+    if(followers.length == 0 || !scene) {
+      throw new Error('Follower IDs and scene ID required');
     }
 
     this.squad = {leader, followers, scene};
@@ -49,6 +49,13 @@ export default class extends Application {
     if (!value) return;
 
     evt.preventDefault();
+    evt.stopPropagation();
+    this.squad.leader ??= game.user.targets.first()?.id;
+
+    if (!this.squad.leader) {
+      ui.notifications.info(MODULE.localize('feedback.pickTarget'));
+      return;
+    }
     
     const formData = {
       'elevation': 'tether',
@@ -78,6 +85,10 @@ export default class extends Application {
   }
 
   async startFollow(squadData) {
+    if (!this.squad.leader) {
+      throw new Error('Leader token required for squadron creation.');
+    }
+
     if (squadData.orientationVector.mode === 'detect') {
       const tRot = this.leader?.rotation; 
       const tRay = Ray.fromAngle(0,0, Math.toRadians(tRot + 90), 1);

--- a/src/apps/Formation/app.mjs
+++ b/src/apps/Formation/app.mjs
@@ -27,7 +27,8 @@ export default class extends Application {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: [...super.defaultOptions.classes, '%config.id%', this.name],
       template: this.template,
-      title: MODULE.format('app.title'),
+      title: 'sqdrn.app.title',
+      id: '%config-id%-Formation',
       top: 150,
     });
   }

--- a/src/apps/Formation/style.scss
+++ b/src/apps/Formation/style.scss
@@ -4,8 +4,10 @@
   grid: 
     "header header header . common" auto
     ".      up      .     . common" auto
-    "left   normal  right . elevation" auto
+    "left   rotation  right . elevation" auto
     ".      down    .     . elevation" auto
+    ".      .    .     . elevation" auto
+    "normal normal  normal . ." auto
     / 1fr 1fr 1fr 5px 2fr;
 
   align-items:center;

--- a/src/apps/Formation/style.scss
+++ b/src/apps/Formation/style.scss
@@ -4,7 +4,7 @@
   grid: 
     "header header header . common" auto
     ".      up      .     . common" auto
-    "left   rotation  right . elevation" auto
+    "left   detect  right . elevation" auto
     ".      down    .     . elevation" auto
     ".      .    .     . elevation" auto
     "normal normal  normal . ." auto

--- a/src/apps/Formation/template.hbs
+++ b/src/apps/Formation/template.hbs
@@ -20,7 +20,7 @@
     class="fa-solid fa-link"
   ></i></button>
 
-<button style="grid-area:rotation" data-tooltip="sqdrn.tips.detect" data-value="rotation"><i
+<button style="grid-area:detect" data-tooltip="sqdrn.tips.detect" data-value="DETECT"><i
     class="fa-solid fa-street-view"
   ></i></button>
 

--- a/src/apps/Formation/template.hbs
+++ b/src/apps/Formation/template.hbs
@@ -1,4 +1,4 @@
-<h2 style="grid-area:header">{{localize 'sqdrn.app.formation'}}<i data-tooltip="{{{localize 'sqdrn.tips.formation'}}}" class="fa-regular fa-circle-question fa-xs"></i></h2>
+<h2 style="grid-area:header">{{localize 'sqdrn.app.formation'}}<i data-tooltip="sqdrn.tips.formation" class="fa-regular fa-circle-question fa-xs"></i></h2>
 
 <button style="grid-area:up;" data-value="UP"><i
     class="fa-solid fa-arrow-up"
@@ -16,36 +16,36 @@
     class="fa-solid fa-arrow-right"
   ></i></button>
 
-<button style="grid-area:normal" data-tooltip="{{{localize 'sqdrn.tips.link'}}}" data-value="SHADOW">{{localize 'sqdrn.app.link'}} <i
+<button style="grid-area:normal" data-tooltip="sqdrn.tips.link" data-value="SHADOW">{{localize 'sqdrn.app.link'}} <i
     class="fa-solid fa-link"
   ></i></button>
 
-<button style="grid-area:rotation" data-tooltip="{{{localize 'sqdrn.tips.detect'}}}" data-value="rotation"><i
+<button style="grid-area:rotation" data-tooltip="sqdrn.tips.detect" data-value="rotation"><i
     class="fa-solid fa-street-view"
   ></i></button>
 
 <form class="flexcol" style="grid-area:elevation;">
   <h3>{{localize 'sqdrn.app.config.elevation'}}</h3>
-  <label data-tooltip="{{{localize 'sqdrn.tips.tethered'}}}">
+  <label data-tooltip="sqdrn.tips.tethered">
     <input type="radio" checked value="tether" name="elevation" />
     {{localize 'sqdrn.elevation.tethered'}}
   </label>
-  <label data-tooltip="{{{localize 'sqdrn.tips.offset'}}}">
+  <label data-tooltip="sqdrn.tips.offset">
     <input type="radio" value="offset" name="elevation" />
     {{localize 'sqdrn.elevation.offset'}}
   </label>
-  <label data-tooltip="{{{localize 'sqdrn.tips.static'}}}">
+  <label data-tooltip="sqdrn.tips.static">
     <input type="radio" value="static" name="elevation" />
     {{localize 'sqdrn.elevation.static'}}
   </label>
 </form>
 <form class="flexcol" style="grid-area:common;">
   <label>
-    <input type="checkbox" data-tooltip="{{{localize 'sqdrn.tips.snap'}}}" checked name="snap-grid" />
+    <input type="checkbox" data-tooltip="sqdrn.tips.snap" checked name="snap-grid" />
     {{localize 'sqdrn.app.config.snap'}}
   </label>
   <label>
-    <input type="checkbox" data-tooltip="{{{localize 'sqdrn.tips.nopause'}}}" name="no-pause" />
+    <input type="checkbox" data-tooltip="sqdrn.tips.nopause" name="no-pause" />
     {{localize 'sqdrn.app.config.nopause'}}
   </label>
 </form>

--- a/src/apps/Formation/template.hbs
+++ b/src/apps/Formation/template.hbs
@@ -16,8 +16,12 @@
     class="fa-solid fa-arrow-right"
   ></i></button>
 
-<button style="grid-area:normal" data-tooltip="{{{localize 'sqdrn.tips.pulled'}}}" data-value="SHADOW"><i
-    class="fa-solid fa-ghost"
+<button style="grid-area:normal" data-tooltip="{{{localize 'sqdrn.tips.link'}}}" data-value="SHADOW">{{localize 'sqdrn.app.link'}} <i
+    class="fa-solid fa-link"
+  ></i></button>
+
+<button style="grid-area:rotation" data-tooltip="{{{localize 'sqdrn.tips.detect'}}}" data-value="rotation"><i
+    class="fa-solid fa-street-view"
   ></i></button>
 
 <form class="flexcol" style="grid-area:elevation;">

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1,0 +1,66 @@
+{
+  "sqdrn": {
+    "app": {
+      "title": "Staffelkonfiguration",
+      "formation": "Bildung",
+      "link": "Link",
+      "config": {
+        "elevation": "Elevation",
+        "snap": "Rastereinrastung",
+        "nopause": "Niemals pausieren"
+      }
+    },
+    "tips": {
+      "tethered": "Die Höhe des Gefolgsmanns wird mit seinem Anführer in Formation gehalten.",
+      "offset": "Die relative Höhe des Followers im Vergleich zu seinem Anführer bleibt erhalten.",
+      "static": "Der Rang des Anhängers wird durch seinen Anführer nicht beeinflusst. ",
+      "snap": "Der Follower rastet bei Bewegungen am Raster ein.",
+      "nopause": "Durch das Verschieben des Anhängermarkers wird dieser nicht daran gehindert, seinem Anführer zu folgen. ",
+      "formation": "Verwenden Sie die Pfeiltasten, um die Richtung dieser Formation auszuwählen.<hr><p style='font-size:smaller;'>Der Formationsmodus hält den Follower in dieser relativen Ausrichtung, während sich sein Anführer bewegt.</p>",
+      "link": "Besteigen, fahren oder verbinden Sie Token auf andere Weise miteinander.<hr><p style='font-size:smaller'>Der verknüpfte Modus spiegelt die Bewegungen ihrer Anführer wider und behält ihre relative Position während der Drehungen bei.</p>",
+      "detect": "Leiten Sie die Richtung der Formation aus der Blickrichtung des Anführers ab."
+    },
+    "elevation": {
+      "tethered": "Angebunden",
+      "offset": "Versatz",
+      "static": "Statisch"
+    },
+    "setting": {
+      "collideWalls": {
+        "name": "Verhalten bei Wandkollisionen",
+        "hint": "Bestimmt, wie ein Follower-Token auf einen Bewegungsblocker auf seinem Weg reagiert.",
+        "cOff": "Ignorieren Sie Wände",
+        "cPause": "Pausieren Sie das Folgen",
+        "cTeleport": "Teleportieren"
+      },
+      "silentCollide": {
+        "name": "Kollisions-Toasts unterdrücken",
+        "hint": "Entfernen Sie die Benachrichtigung, dass ein Token, den Sie besitzen, mit einer Wand kollidiert ist und nicht mehr seinem Anführer folgt."
+      }
+    },
+    "workflow": {
+      "pick": "Wählen Sie den Staffelführer<hr><p style='font-size:smaller'><strong>Ziehen:</strong> Formationsmodus</p><p style='font-size:smaller'><strong>Strg-Ziehen:</strong> Verknüpfter Modus</p><p style='font-size:smaller'><strong>Alt-Ziehen:</strong> Erweiterte Einrichtung</p>",
+      "rejoin": "Treten Sie der Formation wieder bei",
+      "leave": "Formation verlassen"
+    },
+    "feedback": {
+      "pickTarget": "Bitte zielen Sie (Hotkey „t“) auf den Anführermarker für dieses Geschwader.",
+      "pickConfirm": {
+        "formation": "{num} Token befinden sich jetzt in Formation beim Ziel.",
+        "follow": "{num} Token bewegen sich jetzt zusammen mit dem Ziel."
+      },
+      "wallCollision": "Die Bewegung von {tokenName} kollidiert mit einer Wand und hat die Formation verlassen."
+    },
+    "orientation": {
+      "title": "Formationsrichtung wählen",
+      "snapLabel": "Am Raster ausrichten",
+      "lockElevation": "Höhe sperren",
+      "persistLabel": "Folgen Sie immer",
+      "none": "Keiner",
+      "up": "Hoch",
+      "down": "Runter",
+      "left": "Links",
+      "right": "Rechts"
+    }
+  }
+}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -36,6 +36,14 @@
       "silentCollide": {
         "name": "Suppress Collision Toasts",
         "hint": "Remove notification indicating a token you own has collided with a wall and stopped following its leader."
+      },
+      "creationPings": {
+        "name": "Show Creation Pings From",
+        "hint": "Show creation of a new squadron as canvas pings to all connected users.",
+        "all": "Everyone",
+        "players": "Players only",
+        "gm": "GM only",
+        "none": "None (disabled)"
       }
     },
     "workflow": {
@@ -47,7 +55,7 @@
       "pickTarget": "Please target (hotkey \"t\") the leader token for this squadron.",
       "pickConfirm": {
         "formation": "{num} token(s) are now in formation with the target.",
-        "follow": "{num} token(s) are now moving along with the target."
+        "follow": "{num} token(s) are now linked with the target."
       },
       "wallCollision": "{tokenName}'s movement collides with a wall and has left formation."
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -17,7 +17,7 @@
       "snap": "Follower is snapped to grid during movements.",
       "nopause": "Moving the follower token will not pause it from following their leader. Useful for riding vehicles.",
       "formation": "Use the arrow buttons to select the direction of this formation.<hr><p style='font-size:smaller;'>Formation mode keeps the follower in this relative orientation as their leader moves.</p>",
-      "link": "Mount, ride, or otherwise link tokens together.<hr><p style='font-size:smaller'>Linked mode mirrors their leaders movements and maintains its relative position during rotations.</p>",
+      "link": "Mount, ride, or otherwise link tokens together.<hr><p style='font-size:smaller'>Linked mode mirrors their leaders movements and maintains their relative position during rotations.</p>",
       "detect": "Derive formation direction from leader's facing."
     },
     "elevation": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -3,7 +3,7 @@
     "app": {
       "title": "Squadron Configuration",
       "formation": "Formation",
-      "follow": "Follow",
+      "link": "Link",
       "config": {
         "elevation": "Elevation",
         "snap": "Grid Snap",
@@ -14,10 +14,11 @@
       "tethered": "Follower's elevation is kept in formation with their leader.",
       "offset": "Follower's relative elevation compared to their leader is preserved.",
       "static": "Follower's elevation is not affected by their leader. Useful for areas of effect or following a flying token.",
-      "pulled": "Follower shadows their leader's movements. Useful for riding vehicles or joining multiple tokens together.",
       "snap": "Follower is snapped to grid during movements.",
       "nopause": "Moving the follower token will not pause it from following their leader. Useful for riding vehicles.",
-      "formation": "Keep the follower in their relative position (e.g. <q>behind</q> or <q>in front</q>) as the leader moves. Select the direction your leader is moving or the direction the formation is facing."
+      "formation": "Use the arrow buttons to select the direction of this formation.<hr><p style='font-size:smaller;'>Formation mode keeps the follower in this relative orientation as their leader moves.</p>",
+      "link": "Mount, ride, or otherwise link tokens together.<hr><p style='font-size:smaller'>Linked mode mirrors their leaders movements and maintains its relative position during rotations.</p>",
+      "detect": "Derive formation direction from leader's facing."
     },
     "elevation": {
       "tethered": "Tethered",
@@ -38,14 +39,17 @@
       }
     },
     "workflow": {
-      "pick": "Pick Leader",
+      "pick": "Create Squadron<hr><p style='font-size:smaller'><strong>Drag:</strong> join formation with leader</p><p style='font-size:smaller'><strong>Ctrl-Drag:</strong> link to leader</p><p style='font-size:smaller'><strong>Alt-Drag:</strong> advanced config for leader</p>",
       "rejoin": "Rejoin Formation",
       "leave": "Leave Formation"
     },
     "feedback": {
       "pickAsk": "Please select the leader token for {followerName}",
       "pickTarget": "Please target (hotkey \"t\") the leader token for {followerName}",
-      "pickConfirm": "{num} token(s) are now in formation.",
+      "pickConfirm": {
+        "formation": "{num} token(s) are now in formation with the target.",
+        "follow": "{num} token(s) are now moving along with the target."
+      },
       "wallCollision": "{tokenName}'s movement collides with a wall and has left formation."
     },
     "orientation": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -39,13 +39,12 @@
       }
     },
     "workflow": {
-      "pick": "Create Squadron<hr><p style='font-size:smaller'><strong>Drag:</strong> join formation with leader</p><p style='font-size:smaller'><strong>Ctrl-Drag:</strong> link to leader</p><p style='font-size:smaller'><strong>Alt-Drag:</strong> advanced config for leader</p>",
+      "pick": "Choose Squadron Leader<hr><p style='font-size:smaller'><strong>Drag:</strong> Formation mode</p><p style='font-size:smaller'><strong>Ctrl-Drag:</strong> Linked mode</p><p style='font-size:smaller'><strong>Alt-Drag:</strong> Advanced setup</p>",
       "rejoin": "Rejoin Formation",
       "leave": "Leave Formation"
     },
     "feedback": {
-      "pickAsk": "Please select the leader token for {followerName}",
-      "pickTarget": "Please target (hotkey \"t\") the leader token for {followerName}",
+      "pickTarget": "Please target (hotkey \"t\") the leader token for this squadron.",
       "pickConfirm": {
         "formation": "{num} token(s) are now in formation with the target.",
         "follow": "{num} token(s) are now moving along with the target."

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -1,0 +1,66 @@
+{
+  "sqdrn": {
+    "app": {
+      "title": "Configuración del escuadrón",
+      "formation": "Formación",
+      "link": "Enlace",
+      "config": {
+        "elevation": "Elevación",
+        "snap": "Ajuste de cuadrícula",
+        "nopause": "Nunca pausar"
+      }
+    },
+    "tips": {
+      "tethered": "La elevación del seguidor se mantiene en formación con su líder.",
+      "offset": "Se conserva la elevación relativa del seguidor en comparación con su líder.",
+      "static": "La elevación del seguidor no se ve afectada por su líder. ",
+      "snap": "El seguidor se ajusta a la cuadrícula durante los movimientos.",
+      "nopause": "Mover la ficha de seguidor no impedirá que siga a su líder. ",
+      "formation": "Utilice los botones de flecha para seleccionar la dirección de esta formación.<hr><p style='font-size:smaller;'>El modo de formación mantiene al seguidor en esta orientación relativa mientras su líder se mueve.</p>",
+      "link": "Montar, montar o vincular tokens entre sí.<hr><p style='font-size:smaller'>El modo vinculado refleja los movimientos de sus líderes y mantiene su posición relativa durante las rotaciones.</p>",
+      "detect": "Derivar la dirección de la formación a partir de la orientación del líder."
+    },
+    "elevation": {
+      "tethered": "atado",
+      "offset": "Compensar",
+      "static": "Estático"
+    },
+    "setting": {
+      "collideWalls": {
+        "name": "Comportamiento de colisión con la pared",
+        "hint": "Determina cómo responderá una ficha de seguidor a un bloqueador de movimiento a lo largo de su camino.",
+        "cOff": "Ignorar paredes",
+        "cPause": "Pausar siguiendo",
+        "cTeleport": "Teletransportarse"
+      },
+      "silentCollide": {
+        "name": "Suprimir brindis de colisión",
+        "hint": "Elimina la notificación que indica que una ficha de tu propiedad chocó con una pared y dejó de seguir a su líder."
+      }
+    },
+    "workflow": {
+      "pick": "Elige líder de escuadrón<hr><p style='font-size:smaller'><strong>Arrastrar:</strong> Modo de formación</p><p style='font-size:smaller'><strong>Ctrl-Arrastrar:</strong> Modo vinculado</p><p style='font-size:smaller'><strong>Alt-arrastrar:</strong> Configuración avanzada</p>",
+      "rejoin": "Reincorporarse a la formación",
+      "leave": "Dejar la formación"
+    },
+    "feedback": {
+      "pickTarget": "Apunte (tecla de acceso rápido \"t\") a la ficha de líder de este escuadrón.",
+      "pickConfirm": {
+        "formation": "{num} ficha(s) ahora están en formación con el objetivo.",
+        "follow": "{num} token(s) ahora se están moviendo junto con el objetivo."
+      },
+      "wallCollision": "El movimiento de {tokenName} choca contra una pared y ha abandonado la formación."
+    },
+    "orientation": {
+      "title": "Seleccionar dirección de formación",
+      "snapLabel": "Ajustar a cuadrícula",
+      "lockElevation": "Elevación de bloqueo",
+      "persistLabel": "Seguir siempre",
+      "none": "Ninguno",
+      "up": "Arriba",
+      "down": "Abajo",
+      "left": "Izquierda",
+      "right": "Bien"
+    }
+  }
+}

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1,0 +1,66 @@
+{
+  "sqdrn": {
+    "app": {
+      "title": "Configuration de l'escadron",
+      "formation": "Formation",
+      "link": "Lien",
+      "config": {
+        "elevation": "Élévation",
+        "snap": "Accrochage à la grille",
+        "nopause": "Ne jamais faire de pause"
+      }
+    },
+    "tips": {
+      "tethered": "L'élévation du suiveur est maintenue en formation avec son chef.",
+      "offset": "L'élévation relative du suiveur par rapport à son leader est préservée.",
+      "static": "L'élévation du suiveur n'est pas affectée par son chef. ",
+      "snap": "Le suiveur est accroché à la grille pendant les mouvements.",
+      "nopause": "Déplacer le jeton suiveur ne l’empêchera pas de suivre son chef. ",
+      "formation": "Utilisez les boutons fléchés pour sélectionner la direction de cette formation.<hr><p style='font-size:smaller;'>Le mode Formation maintient le suiveur dans cette orientation relative lorsque son leader se déplace.</p>",
+      "link": "Montez, montez ou reliez les jetons ensemble.<hr><p style='font-size:smaller'>Le mode lié reflète les mouvements de leurs leaders et maintient sa position relative pendant les rotations.</p>",
+      "detect": "Dérivez la direction de la formation à partir de l’orientation du leader."
+    },
+    "elevation": {
+      "tethered": "Attaché",
+      "offset": "Compenser",
+      "static": "Statique"
+    },
+    "setting": {
+      "collideWalls": {
+        "name": "Comportement en cas de collision avec un mur",
+        "hint": "Détermine comment un jeton suiveur répondra à un bloqueur de mouvement le long de son chemin.",
+        "cOff": "Ignorer les murs",
+        "cPause": "Suspendre le suivi",
+        "cTeleport": "Téléportation"
+      },
+      "silentCollide": {
+        "name": "Supprimer les toasts de collision",
+        "hint": "Supprimez la notification indiquant qu'un jeton que vous possédez est entré en collision avec un mur et a cessé de suivre son chef."
+      }
+    },
+    "workflow": {
+      "pick": "Choisissez le chef d'escadron<hr><p style='font-size:smaller'><strong>Traîner:</strong> Mode formation</p><p style='font-size:smaller'><strong>Ctrl-glisser :</strong> Mode lié</p><p style='font-size:smaller'><strong>Alt-Drag :</strong> Configuration avancée</p>",
+      "rejoin": "Rejoindre la formation",
+      "leave": "Quitter la formation"
+    },
+    "feedback": {
+      "pickTarget": "Veuillez cibler (raccourci \"t\") le jeton de chef de cet escadron.",
+      "pickConfirm": {
+        "formation": "{num} jeton(s) sont maintenant en formation avec la cible.",
+        "follow": "{num} jeton(s) se déplacent désormais avec la cible."
+      },
+      "wallCollision": "Le mouvement de {tokenName} entre en collision avec un mur et a quitté la formation."
+    },
+    "orientation": {
+      "title": "Sélectionnez la direction de la formation",
+      "snapLabel": "Accrocher à la grille",
+      "lockElevation": "Verrouiller l'élévation",
+      "persistLabel": "Suivez toujours",
+      "none": "Aucun",
+      "up": "En haut",
+      "down": "Vers le bas",
+      "left": "Gauche",
+      "right": "Droite"
+    }
+  }
+}

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1,27 +1,62 @@
 {
   "sqdrn": {
+    "app": {
+      "title": "飛行隊構成",
+      "formation": "形成",
+      "link": "リンク",
+      "config": {
+        "elevation": "標高",
+        "snap": "グリッドスナップ",
+        "nopause": "決して一時停止しないでください"
+      }
+    },
+    "tips": {
+      "tethered": "フォロワーの昇格はリーダーとのフォーメーションを維持します。",
+      "offset": "リーダーと比較したフォロワーの相対的な標高は維持されます。",
+      "static": "フォロワーの昇格はリーダーの影響を受けません。",
+      "snap": "フォロワーは移動中にグリッドにスナップされます。",
+      "nopause": "フォロワー トークンを移動しても、リーダーのフォローは一時停止されません。",
+      "formation": "矢印ボタンを使用して、このフォーメーションの方向を選択します。<hr><p style='font-size:smaller;'>フォーメーション モードでは、リーダーが移動しても、フォロワーはこの相対的な方向を維持します。</p>",
+      "link": "トークンをマウント、ライド、またはその他の方法でリンクします。<hr><p style='font-size:smaller'>リンク モードはリーダーの動きを反映し、回転中にその相対位置を維持します。</p>",
+      "detect": "リーダーの向きからフォーメーションの方向を導き出します。"
+    },
+    "elevation": {
+      "tethered": "テザード",
+      "offset": "オフセット",
+      "static": "静的"
+    },
     "setting": {
-      "debug": {
-        "name": "デバッグ有効",
-        "hint": "コンソールに追加のデバッグ情報を表示"
-      },
       "collideWalls": {
-        "name": "壁の衝突判定",
-        "hint": "従者が移動する時、途中に壁があるかどうかを判定し、衝突する場合は一時的に陣形を離脱し停止します。追従を再び有効にするには位置を変えてから陣形に戻してください。"
+        "name": "壁衝突挙動",
+        "hint": "フォロワー トークンがパスに沿った移動ブロッカーにどのように反応するかを決定します。",
+        "cOff": "壁を無視する",
+        "cPause": "フォローを一時停止する",
+        "cTeleport": "テレポート"
+      },
+      "silentCollide": {
+        "name": "衝突トーストの抑制",
+        "hint": "あなたが所有するトークンが壁に衝突し、そのリーダーの追跡を停止したことを示す通知を削除します。"
       }
     },
     "workflow": {
-      "pick": "リーダー選択",
-      "rejoin": "陣形に戻る",
-      "leave": "陣形を離脱する"
+      "pick": "中隊リーダーを選択する<hr><p style='font-size:smaller'><strong>ドラッグ：</strong> フォーメーションモード</p><p style='font-size:smaller'><strong>Ctrl キーを押しながらドラッグ:</strong> リンクモード</p><p style='font-size:smaller'><strong>Alt キーを押しながらドラッグ:</strong> 高度なセットアップ</p>",
+      "rejoin": "フォーメーションに再参加する",
+      "leave": "リーブフォーメーション"
     },
     "feedback": {
-      "pickAsk": "{followerName}が追従するコマを選択してください。",
-      "pickConfirm": "{leaderName}は{followerName}に追従されています。",
-      "wallCollision": "{tokenName}の移動が壁に衝突しましたので一時的に陣形を離脱しました。（コマ[{tokenId}]）"
+      "pickTarget": "この中隊のリーダー トークンをターゲット (ホットキー「t」) してください。",
+      "pickConfirm": {
+        "formation": "現在、{num} 個のトークンがターゲットと形成されています。",
+        "follow": "{num} 個のトークンがターゲットとともに移動中です。"
+      },
+      "wallCollision": "{tokenName} の移動により壁に衝突し、隊列が外れてしまいました。"
     },
     "orientation": {
-      "title": "陣形の方向を選択してください。",
+      "title": "形成方向を選択してください",
+      "snapLabel": "グリッドにスナップ",
+      "lockElevation": "ロックの標高",
+      "persistLabel": "常にフォローする",
+      "none": "なし",
       "up": "上",
       "down": "下",
       "left": "左",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -1,0 +1,66 @@
+{
+  "sqdrn": {
+    "app": {
+      "title": "Configuração do Esquadrão",
+      "formation": "Formação",
+      "link": "Link",
+      "config": {
+        "elevation": "Elevação",
+        "snap": "Ajuste à grade",
+        "nopause": "Nunca pause"
+      }
+    },
+    "tips": {
+      "tethered": "A elevação do seguidor é mantida em formação com seu líder.",
+      "offset": "A elevação relativa do seguidor em relação ao seu líder é preservada.",
+      "static": "A elevação do seguidor não é afetada pelo seu líder. ",
+      "snap": "O seguidor é ajustado à grade durante os movimentos.",
+      "nopause": "Mover o token de seguidor não o impedirá de seguir seu líder. ",
+      "formation": "Use os botões de seta para selecionar a direção desta formação.<hr><p style='font-size:smaller;'>O modo de formação mantém o seguidor nesta orientação relativa enquanto o líder se move.</p>",
+      "link": "Monte, monte ou vincule tokens de outra forma.<hr><p style='font-size:smaller'>O modo vinculado reflete os movimentos de seus líderes e mantém sua posição relativa durante as rotações.</p>",
+      "detect": "Derive a direção da formação a partir da orientação do líder."
+    },
+    "elevation": {
+      "tethered": "Amarrado",
+      "offset": "Desvio",
+      "static": "Estático"
+    },
+    "setting": {
+      "collideWalls": {
+        "name": "Comportamento de colisão de parede",
+        "hint": "Determina como um token seguidor responderá a um bloqueador de movimento ao longo de seu caminho.",
+        "cOff": "Ignorar paredes",
+        "cPause": "Pausar seguindo",
+        "cTeleport": "Teleporte"
+      },
+      "silentCollide": {
+        "name": "Suprimir brindes de colisão",
+        "hint": "Remova a notificação indicando que um token que você possui colidiu com uma parede e parou de seguir seu líder."
+      }
+    },
+    "workflow": {
+      "pick": "Escolha o líder do esquadrão<hr><p style='font-size:smaller'><strong>Arrastar:</strong> Modo de formação</p><p style='font-size:smaller'><strong>Ctrl-Arrastar:</strong> Modo vinculado</p><p style='font-size:smaller'><strong>Alt-Arrastar:</strong> Configuração avançada</p>",
+      "rejoin": "Reingressar na formação",
+      "leave": "Sair da formação"
+    },
+    "feedback": {
+      "pickTarget": "Por favor, direcione (tecla de atalho \"t\") o token de líder deste esquadrão.",
+      "pickConfirm": {
+        "formation": "{num} token(s) agora estão em formação com o alvo.",
+        "follow": "{num} token(s) agora estão se movendo junto com o alvo."
+      },
+      "wallCollision": "O movimento de {tokenName} colide com uma parede e sai da formação."
+    },
+    "orientation": {
+      "title": "Selecione a direção da formação",
+      "snapLabel": "Ajustar à grade",
+      "lockElevation": "Elevação de bloqueio",
+      "persistLabel": "Sempre siga",
+      "none": "Nenhum",
+      "up": "Acima",
+      "down": "Abaixo",
+      "left": "Esquerda",
+      "right": "Certo"
+    }
+  }
+}

--- a/src/modules/logistics.mjs
+++ b/src/modules/logistics.mjs
@@ -202,8 +202,9 @@ export class Logistics {
 
     /* Compute X/Y depending on mode */
     if (orientation.mode == 'rel') {
-      pos.x = token.x + orientation.x * forwardVector.dx;
-      pos.y = token.y + orientation.y * forwardVector.dy;
+      /* Grab the token's _final_ position in case we are still animating */
+      pos.x = token._source.x + orientation.x * forwardVector.dx;
+      pos.y = token._source.y + orientation.y * forwardVector.dy;
       if (forwardVector.dt) {
         const ray = new Ray(origin, {x: pos.x + width/2, y: pos.y + height/2}).shiftAngle(-forwardVector.dt);
         pos = {

--- a/src/modules/logistics.mjs
+++ b/src/modules/logistics.mjs
@@ -15,6 +15,9 @@ export class FollowVector extends Ray {
      * @type {number}
      */
     this.dz = B.z - A.z;
+
+    this.t0 = A.t;
+    this.dt = B.t - A.t;
   }
 }
 
@@ -152,7 +155,7 @@ export class Logistics {
       /* this was serialized from another client */
       followVector = new FollowVector(followVector.A, followVector.B);
     }
-
+    
     /* record last user in case of collision */
     const user = token.getFlag('%config.id%', MODULE.FLAG.lastUser) ?? {};
 
@@ -162,7 +165,7 @@ export class Logistics {
 
     /* snap to the grid if requested.*/
     if (snap) {
-      foundry.utils.mergeObject(position, token.parent.grid.getSnappedPoint(position, {mode: CONST.GRID_SNAPPING_MODES.TOP_LEFT_CORNER}));
+      foundry.utils.mergeObject(position, token.parent.grid.getSnappedPoint(position, {mode: CONST.GRID_SNAPPING_MODES.CORNER}));
     }
 
     /* check if we have moved -- i.e. on the 2d canvas */
@@ -194,14 +197,22 @@ export class Logistics {
   static _calculateNewPosition(forwardVector, delta, locks, token){
     const origin = forwardVector.A;
     const {angle, distance, dz, orientation} = delta; 
+    const {height, width} = MODULE.getSize(token);
     let pos = {};
 
     /* Compute X/Y depending on mode */
-    if (delta.orientation.mode == 'rel') {
+    if (orientation.mode == 'rel') {
       pos.x = token.x + orientation.x * forwardVector.dx;
       pos.y = token.y + orientation.y * forwardVector.dy;
+      if (forwardVector.dt) {
+        const ray = new Ray(origin, {x: pos.x + width/2, y: pos.y + height/2}).shiftAngle(-forwardVector.dt);
+        pos = {
+          x: ray.B.x - width/2,
+          y: ray.B.y - height/2,
+        }
+      }
     } else {
-      const offsetAngle = forwardVector.angle;
+      const offsetAngle = forwardVector.distance < 1e-10 ? forwardVector.A.t : forwardVector.angle;
 
       /* if planar locked preserve initial orientation */
       const finalAngle = offsetAngle + angle;
@@ -209,8 +220,7 @@ export class Logistics {
       const newLocation = Ray.fromAngle(origin.x, origin.y, finalAngle, distance);
 
       // give x/y if any 2d movement occured
-      if (forwardVector.dx || forwardVector.dy){
-        const {height, width} = MODULE.getSize(token);
+      if (forwardVector.dx || forwardVector.dy || forwardVector.dt){
         pos.x = newLocation.B.x - width/2;
         pos.y = newLocation.B.y - height/2;
       }
@@ -277,11 +287,13 @@ export class Logistics {
       })
     }
 
-    await game.scenes.get(eventData.leader.sceneId).updateEmbeddedDocuments('Token', sortedActions.stops, {squadronEvent: MODULE.EVENT.leaderMove});
+    const scene = game.scenes.get(eventData.leader.sceneId);
 
-    await game.scenes.get(eventData.leader.sceneId).updateEmbeddedDocuments('Token', sortedActions.teleports, {teleport: true, squadronEvent: MODULE.EVENT.leaderMove})
+    await scene.updateEmbeddedDocuments('Token', sortedActions.stops, {squadronEvent: MODULE.EVENT.leaderMove});
 
-    return game.scenes.get(eventData.leader.sceneId).updateEmbeddedDocuments('Token', sortedActions.moves, {squadronEvent: MODULE.EVENT.leaderMove})
+    await scene.updateEmbeddedDocuments('Token', sortedActions.teleports, {teleport: true, squadronEvent: MODULE.EVENT.leaderMove})
+
+    return scene.updateEmbeddedDocuments('Token', sortedActions.moves, {squadronEvent: MODULE.EVENT.leaderMove})
   }
 
   static async handleRemoveFollower(eventData) {

--- a/src/modules/lookout.mjs
+++ b/src/modules/lookout.mjs
@@ -77,20 +77,18 @@ export class Lookout {
     Logistics.announceStopFollow(tokenDoc);
   }
 
-  static _shouldTrack(change) {
-    return (
-      typeof change.x === "number"
+  static _shouldTrack(change, ignoreRotation = false) {
+    const position = typeof change.x === "number"
       || typeof change.y === "number"
       || typeof change.elevation === "number"
-      || typeof change.rotation === "number"
-    );
+    return ignoreRotation ? position : (position || typeof change.rotation === "number");
   }
 
   static _getLocation(tokenDoc, changes = {}) {
     const {width, height} = MODULE.getSize(tokenDoc);
     return {
-      x: (changes.x ?? tokenDoc.x) + width/2,
-      y: (changes.y ?? tokenDoc.y) + height/2,
+      x: (changes.x ?? tokenDoc._source.x) + width/2,
+      y: (changes.y ?? tokenDoc._source.y) + height/2,
       z: changes.elevation ?? tokenDoc.elevation,
       t: Math.toRadians((changes.rotation ?? tokenDoc.rotation) - 90),
     };
@@ -117,7 +115,6 @@ export class Lookout {
 
         const newLoc = Lookout._getLocation(tokenDoc, update);
         const followVector = new FollowVector(newLoc, options.oldLoc[tokenDoc.id]);
-        console.log('old', options.oldLoc[tokenDoc.id], 'new', newLoc, 'vector', followVector);
         const data = {
           leader: {
             tokenId: tokenDoc.id,
@@ -129,16 +126,16 @@ export class Lookout {
 
         MODULE.comms.emit(MODULE.EVENT.leaderMove, data);
       }
+      
       // FOLLOWERS
       if (options.squadronEvent == MODULE.EVENT.leaderMove) {
         /* do not respond to our own move events */
         return;
       }
 
-      /* am I a follower? */
-      const leaders = tokenDoc.getFlag('%config.id%', MODULE.FLAG.leaders) ?? {};
-      if (Object.keys(leaders).length > 0) {
-        /* I am following someone and have moved independently of them -> Pause */
+      /* am I a follower and this movement is not only rotation? Pause */
+      const leaders = tokenDoc.getFlag('%config.id%', MODULE.FLAG.leaders);
+      if (leaders && Object.keys(leaders).length > 0 && Lookout._shouldTrack(update, true)) {
         Lookout.pause(tokenDoc);
       }
     }

--- a/src/modules/lookout.mjs
+++ b/src/modules/lookout.mjs
@@ -79,9 +79,10 @@ export class Lookout {
 
   static _shouldTrack(change) {
     return (
-      typeof change.x === "number" ||
-      typeof change.y === "number" ||
-      typeof change.elevation === "number"
+      typeof change.x === "number"
+      || typeof change.y === "number"
+      || typeof change.elevation === "number"
+      || typeof change.rotation === "number"
     );
   }
 
@@ -91,6 +92,7 @@ export class Lookout {
       x: (changes.x ?? tokenDoc.x) + width/2,
       y: (changes.y ?? tokenDoc.y) + height/2,
       z: changes.elevation ?? tokenDoc.elevation,
+      t: Math.toRadians((changes.rotation ?? tokenDoc.rotation) - 90),
     };
   }
 
@@ -115,7 +117,7 @@ export class Lookout {
 
         const newLoc = Lookout._getLocation(tokenDoc, update);
         const followVector = new FollowVector(newLoc, options.oldLoc[tokenDoc.id]);
-
+        console.log('old', options.oldLoc[tokenDoc.id], 'new', newLoc, 'vector', followVector);
         const data = {
           leader: {
             tokenId: tokenDoc.id,

--- a/src/modules/module.mjs
+++ b/src/modules/module.mjs
@@ -28,6 +28,7 @@ export class MODULE {
     RIGHT: Object.freeze({x:-1, y:0, mode:'vector'}),
     SHADOW: Object.freeze({x:-1, y:-1, z:-1, mode:'rel'}),
     MIRROR: Object.freeze({x:1, y:1, z:1, mode:'rel'}),
+    DETECT: Object.freeze({x: 0, y: 0, z: 0, mode: 'detect'}),
     QUERY: true,
   })
 

--- a/src/modules/module.mjs
+++ b/src/modules/module.mjs
@@ -63,8 +63,14 @@ export class MODULE {
     return game.user.id === MODULE.firstGM()?.id;
   }
 
+  static setTargets(placeables = []) {
+    const ids = placeables.map( p => p?.id );
+    game.user.broadcastActivity({targets: ids})
+    game.user.updateTokenTargets(ids);
+  }
+
   static getSize(tokenDoc) {
-    if (tokenDoc.object) return tokenDoc.object.getSize();
+    if (tokenDoc.object) return tokenDoc.object.bounds;
     
     let {width, height} = tokenDoc;
     const grid = tokenDoc.parent.grid;

--- a/src/modules/user-interface.mjs
+++ b/src/modules/user-interface.mjs
@@ -13,6 +13,8 @@ export class UserInterface {
     },
   });
 
+  static _dragImg = null;
+
   static register() {
     this.settings();
     this.hooks();
@@ -30,8 +32,14 @@ export class UserInterface {
   }
 
   static hooks(){
+    Hooks.once('renderTokenHUD', this._cacheDragImg);
     Hooks.on('renderTokenHUD', this._renderTokenHUD);
     Hooks.on('dropCanvasData', this._onCanvasDrop);
+  }
+
+  static _cacheDragImg() {
+    UserInterface._dragImg = new Image();
+    UserInterface._dragImg.src = 'icons/svg/target.svg';
   }
 
   static _renderTokenHUD(app, html){
@@ -59,8 +67,7 @@ export class UserInterface {
             followers: canvas.tokens.controlled.map( p => p.id ),
             scene: canvas.scene.id,
           }).render(true);
-        });
-      UserInterface._dragDrop.bind(html[0]);
+        }, true);
     } else {
 
       /* otherwise, we are following normally and have the option to stop */
@@ -69,7 +76,7 @@ export class UserInterface {
     }
   }
 
-  static _addHudButton(html, selectedToken, title, icon, clickEvent) {
+  static _addHudButton(html, selectedToken, title, icon, clickEvent, draggable = false) {
 
     if (!selectedToken) return;
     
@@ -81,23 +88,45 @@ export class UserInterface {
     const iconElement = document.createElement('i');
     iconElement.classList.add('fas', icon);
     button.firstElementChild.append(iconElement);
-
     button.firstElementChild.addEventListener('click', clickEvent);
+
     html[0].querySelector('.col.left').append(button);
+    if (draggable) {
+      UserInterface._dragDrop.bind(html[0]);
+      html[0].addEventListener('dragend', UserInterface._onDragEnd)
+    }
   }
+
+  static _initialTransform = 'inherit';
 
   static _shrinkHUD(hud) {
     if (!hud) return;
-    hud.element[0].style.transition = 'scale 0.5s';
-    hud.element[0].style.transformOrigin = 'center';
-    hud.element[0].style.scale = 0.5;
+    const el = hud.element[0];
+    el.style.transition = 'transform 0.5s ease-in';
+    UserInterface._initialTransform = el.style.transform;
+    el.style.transform += ' scale(0.5) translate(50%, 50%)';
   }
 
+  /**
+   * Restores HUD to initial styling. Half second delay to match UserInterface._shrinkHUD.
+   *
+   * @static
+   * @param {TokenHUD} hud
+   * @returns Promise<> Restore  HUD animation has completed
+   * @memberof UserInterface
+   */
   static _restoreHUD(hud) {
     if (!hud) return;
-    hud.element[0].style.transformOrigin = 'inherit';
-    hud.element[0].style.scale = 'inherit';
-    hud.element[0].style.transition = 'inherit';
+    hud.element[0].style.transform = UserInterface._initialTransform;
+
+    return new Promise( resolve => (setTimeout( () => {
+      hud.element[0].style.transition = 'inherit'
+      resolve();
+    }, 500)));
+  }
+
+  static _onDragEnd(evt) {
+    UserInterface._restoreHUD(canvas.tokens.hud)
   }
 
   static _onDragStart(evt) {
@@ -107,13 +136,19 @@ export class UserInterface {
       alt: evt.altKey,
       ctrl: evt.ctrlKey,
     }
+    //evt.stopPropagation();
     evt.dataTransfer.setData("text/plain", JSON.stringify(dragData));
+    const {width, height} = evt.target.getBoundingClientRect();
+    const preview = DragDrop.createDragImage(UserInterface._dragImg, width, height);
+    evt.dataTransfer.setDragImage(preview, width/2, height/2);
+    evt.dataTransfer.effectAllowed = 'link';
+    evt.dataTransfer.dropEffect = 'link';
     UserInterface._shrinkHUD(canvas.tokens.hud);
   }
 
   static _onCanvasDrop(canvas, {type, selected = [], x, y, alt, ctrl}) {
     if (type !== '%config.id%/target' || selected?.length == 0) return;
-
+    
     UserInterface._restoreHUD(canvas.tokens.hud);
 
     /* create 20x20 target area to find placeables */
@@ -123,6 +158,7 @@ export class UserInterface {
       if (token._overlapsSelection(hitArea)) targets.push(token);
     }
     targets.sort( (left, right) => left.document.sort > right.document.sort ? -1 : left.document.sort < right.document.sort ? 1 : 0);
+
     
     if (targets.length > 0) {
       const formation = new Formation({
@@ -132,17 +168,22 @@ export class UserInterface {
       });
 
       if (alt) {
+        MODULE.setTargets([targets.at(0)]);
         formation.render(true);
+
       } else if (ctrl) {
-        formation.startFollow({
-          orientationVector: MODULE.CONST.SHADOW,
-          snap: false,
-          locks: {
-            elevation: 'offset', 
-            follow: true,
-          }
-        });
+        UserInterface._restoreHUD(canvas.tokens.hud).then( _ => {
+          formation.startFollow({
+            orientationVector: MODULE.CONST.SHADOW,
+            snap: false,
+            locks: {
+              elevation: 'offset', 
+              follow: true,
+            }
+          });
+      })
       } else {
+        UserInterface._restoreHUD(canvas.tokens.hud).then( _ => {
           formation.startFollow({
             orientationVector: MODULE.CONST.DETECT,
             snap: true,
@@ -151,6 +192,7 @@ export class UserInterface {
               follow: false,
             }
           });
+        });
       }
     }
 
@@ -160,11 +202,15 @@ export class UserInterface {
   static async stop(followerToken) {
     await Logistics.announceStopFollow(followerToken);
     await followerToken.update({'flags.-=%config.id%': null});
-    if (canvas.tokens.hud.object?.id === followerToken.id) canvas.tokens.hud.render(false);
+    if (canvas.tokens.hud.object?.id === followerToken.id) {
+      canvas.tokens.hud.render(false);
+    }
   }
 
   static async resume(followerToken) {
     await followerToken.setFlag('%config.id%', MODULE.FLAG.paused, false);
-    if (canvas.tokens.hud.object?.id === followerToken.id) canvas.tokens.hud.render(false);
+    if (canvas.tokens.hud.object?.id === followerToken.id) {
+      canvas.tokens.hud.render(false);
+    }
   }
 }

--- a/src/modules/user-interface.mjs
+++ b/src/modules/user-interface.mjs
@@ -149,7 +149,7 @@ export class UserInterface {
   static _onCanvasDrop(canvas, {type, selected = [], x, y, alt, ctrl}) {
     if (type !== '%config.id%/target' || selected?.length == 0) return;
     
-    UserInterface._restoreHUD(canvas.tokens.hud);
+    const anim = UserInterface._restoreHUD(canvas.tokens.hud);
 
     /* create 20x20 target area to find placeables */
     let targets = [];
@@ -172,7 +172,7 @@ export class UserInterface {
         formation.render(true);
 
       } else if (ctrl) {
-        UserInterface._restoreHUD(canvas.tokens.hud).then( _ => {
+        anim.then( _ => {
           formation.startFollow({
             orientationVector: MODULE.CONST.SHADOW,
             snap: false,
@@ -181,9 +181,9 @@ export class UserInterface {
               follow: true,
             }
           });
-      })
+        })
       } else {
-        UserInterface._restoreHUD(canvas.tokens.hud).then( _ => {
+        anim.then( _ => {
           formation.startFollow({
             orientationVector: MODULE.CONST.DETECT,
             snap: true,

--- a/src/modules/user-interface.scss
+++ b/src/modules/user-interface.scss
@@ -1,0 +1,13 @@
+#token-hud .control-icon.%config.id%[draggable="true"] {
+  cursor: grab;
+  transition: scale 0.25s ease-in, box-shadow 0.25s ease-in;
+  box-shadow: 2px 2px 3px var(--color-shadow-dark); 
+  &:hover {
+    scale: 1.1;
+    box-shadow: 4px 4px 8px 3px var(--color-shadow-dark)
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+}

--- a/src/modules/user-interface.scss
+++ b/src/modules/user-interface.scss
@@ -1,9 +1,9 @@
 #token-hud .control-icon.%config.id%[draggable="true"] {
   cursor: grab;
-  transition: scale 0.25s ease-in, box-shadow 0.25s ease-in;
+  transition: transform 0.25s ease-in, box-shadow 0.25s ease-in;
   box-shadow: 2px 2px 3px var(--color-shadow-dark); 
   &:hover {
-    scale: 1.1;
+    transform: scale(1.1);
     box-shadow: 4px 4px 8px 3px var(--color-shadow-dark)
   }
 

--- a/src/modules/user-interface.scss
+++ b/src/modules/user-interface.scss
@@ -1,13 +1,16 @@
-#token-hud .control-icon.%config.id%[draggable="true"] {
-  cursor: grab;
+#token-hud .control-icon.%config.id% {
   transition: transform 0.25s ease-in, box-shadow 0.25s ease-in;
   box-shadow: 2px 2px 3px var(--color-shadow-dark); 
-  &:hover {
-    transform: scale(1.1);
-    box-shadow: 4px 4px 8px 3px var(--color-shadow-dark)
-  }
+  &[draggable="true"] {
+    cursor: grab;
 
-  &:active {
-    cursor: grabbing;
+    &:hover {
+      transform: scale(1.1);
+      box-shadow: 4px 4px 8px 3px var(--color-shadow-dark)
+    }
+
+    &:active {
+      cursor: grabbing;
+    }
   }
 }

--- a/src/squadron.bd.json
+++ b/src/squadron.bd.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "core": [
       "12",
-      "12.327"
+      "12.331"
     ]
   },
   "authors": [


### PR DESCRIPTION
* Added new drag-drop-based workflow
  * Drag Squadron's TokenHUD control onto desired leader token (in lieu of targeting) to quickly create a squadron.
  * Holding CTRL or ALT before starting the drag modifies the squadron creation.

| Drag Modifier | Grid Snap | Never Pause | Elevation | Mode |
| :----: | :--: | :--: | :--: | -- |
| _(none)_   | ✔️ | ✖️ | ✔️ | **Formation**: keeps the follower in this relative orientation as their leader moves. |
| CTRL   | ✖️ | ✔️ | 🟰 | **Linked**: mirrors their leaders movements and maintains their relative position during rotations. Useful for mounting or riding vehicles |
| ALT  | ❔| ❔| ❔| **Advanced**: Opens the squadron configuration dialog with indicated leader pre-targeted. |

* Refactored target-based workflow
  * Via click or alt-drag, the squadron configuration dialog will be shown without a leader being targeted.
  * Squadron leader is latched at time of config submission using the first token currently targeted.

* Improved squadron creation feedback
  * Leader tokens are pinged with a chevron.
  * Follower tokens are pinged based on the chosen mode
    * Formation - pinged with an arrow indicating the formation's direction.
    * Linked - pinged with a pulse.
  * Setting added to control from which users pings are shown; From everyone (default), only from GMs (and Assistants), only from Players (and Trusted), or from no one (disables ping feedback).

* Added rotation awareness for all squadron modes
  * Rotating a **leader** token will trigger relevant follower movements.
  * Rotating a **follower** token will not pause its squadron movements.

* Corrected token size and position calculations
  * Avoids small accumulating errors in follower's position relative to its leader in linked mode, and small offset in formation mode.
  * Stabilizes relative position calc when leader or follower are moved mid-canvas-animation.

* Added machine translated language files for updated tooltips and phrasing.